### PR TITLE
Bump package.json to work with react 19

### DIFF
--- a/react-native/package.json
+++ b/react-native/package.json
@@ -32,7 +32,7 @@
     "LICENSE"
   ],
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-native": ">=0.60.0",
     "react-native-svg": ">=12.0.0"
   },

--- a/react/package.json
+++ b/react/package.json
@@ -29,7 +29,7 @@
     "LICENSE"
   ],
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "dependencies": {
     "@cardog-icons/core": "workspace:*"


### PR DESCRIPTION
Thanks for this great library! Would be great to bump the react version as this works just as well on react 19, making it compatible with the newer version.