### PR TITLE
refresh(web): flatter, more modern design system

### DIFF
--- a/web/src/app/docs/page.tsx
+++ b/web/src/app/docs/page.tsx
@@ -4,7 +4,9 @@ import { ChevronRight, Moon, Sun } from "lucide-react";
 export default function DocsPage() {
   return (
     <div className="container py-8 md:py-12">
-      <h1 className="text-3xl font-bold mb-4">Documentation</h1>
+      <h1 className="text-3xl font-semibold tracking-tight md:text-4xl mb-4">
+        Documentation
+      </h1>
       <p className="text-lg text-muted-foreground mb-8 max-w-3xl">
         Get started with Cardog Icons, a beautiful and consistent icon library
         for your web and mobile applications. Now with{" "}
@@ -14,8 +16,8 @@ export default function DocsPage() {
 
       <div className="space-y-10">
         {/* What's New */}
-        <div className="p-6 rounded-xl bg-gradient-to-br from-bernese-400/20 to-bernese-300/5 border border-bernese-400/30">
-          <h2 className="text-xl font-bold mb-3 flex items-center gap-2">
+        <div className="p-6 rounded-xl border border-border bg-muted/40">
+          <h2 className="text-xl font-semibold tracking-tight mb-3 flex items-center gap-2">
             <span className="text-2xl">✨</span> What's New in v1.1.0
           </h2>
           <ul className="space-y-2 text-muted-foreground">
@@ -41,7 +43,7 @@ export default function DocsPage() {
 
         {/* Quick Start */}
         <div>
-          <h2 className="text-2xl font-bold mb-4">Quick Start</h2>
+          <h2 className="text-2xl font-semibold tracking-tight mb-4">Quick Start</h2>
           <div className="prose prose-stone dark:prose-invert max-w-none">
             <p>
               Install the package with your preferred package manager:
@@ -86,7 +88,7 @@ function MyComponent() {
 
         {/* Icon Variants */}
         <div>
-          <h2 className="text-2xl font-bold mb-4">Icon Variants</h2>
+          <h2 className="text-2xl font-semibold tracking-tight mb-4">Icon Variants</h2>
           <div className="grid md:grid-cols-2 gap-4">
             <div className="p-4 rounded-lg border bg-background">
               <div className="flex items-center gap-2 mb-2">
@@ -119,7 +121,7 @@ function MyComponent() {
 
         {/* Naming Convention */}
         <div>
-          <h2 className="text-2xl font-bold mb-4">Naming Convention</h2>
+          <h2 className="text-2xl font-semibold tracking-tight mb-4">Naming Convention</h2>
           <div className="prose prose-stone dark:prose-invert max-w-none">
             <p>Icons follow a consistent naming pattern:</p>
             <div className="my-4 overflow-x-auto">
@@ -160,7 +162,7 @@ function MyComponent() {
 
         {/* React Native */}
         <div>
-          <h2 className="text-2xl font-bold mb-4">Usage with React Native</h2>
+          <h2 className="text-2xl font-semibold tracking-tight mb-4">Usage with React Native</h2>
           <div className="prose prose-stone dark:prose-invert max-w-none">
             <p>
               For React Native applications, install the dedicated package:
@@ -205,7 +207,7 @@ function MyScreen() {
 
         {/* Props */}
         <div>
-          <h2 className="text-2xl font-bold mb-4">Props</h2>
+          <h2 className="text-2xl font-semibold tracking-tight mb-4">Props</h2>
           <div className="prose prose-stone dark:prose-invert max-w-none">
             <p>All icon components accept standard SVG props:</p>
             <div className="my-4 overflow-x-auto">

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -2,83 +2,78 @@
 @tailwind components;
 @tailwind utilities;
 
-body {
-  font-family: Arial, Helvetica, sans-serif;
-}
-
 @layer base {
   :root {
-    --background: 30 36% 96%;
-    --foreground: 0 0% 9%;
-    --card: 30 43% 97%;
-    --card-foreground: 0 0% 3.9%;
-    --popover: 30 43% 97%;
-    --popover-foreground: 0 0% 3.9%;
-    --primary: 224 100% 91%;
-    --primary-foreground: 0 0% 9%;
-    --secondary: 25 48% 56%;
-    --secondary-foreground: 0 0% 9%;
-    --muted: 0 0% 96.1%;
-    --muted-foreground: 0 0% 45.1%;
-    --accent: 0 0% 96.1%;
-    --accent-foreground: 0 0% 9%;
-    --destructive: 0 84.2% 60.2%;
+    /* Warm cream surface, ink ink, flat layering — no elevation. */
+    --background: 36 33% 96%;
+    --foreground: 24 10% 10%;
+    --card: 40 40% 99%;
+    --card-foreground: 24 10% 10%;
+    --popover: 40 40% 99%;
+    --popover-foreground: 24 10% 10%;
+    /* Ink primary for crisp, modern, high-contrast actions. */
+    --primary: 24 10% 10%;
+    --primary-foreground: 40 40% 98%;
+    --secondary: 33 24% 91%;
+    --secondary-foreground: 24 10% 14%;
+    --muted: 33 22% 92%;
+    --muted-foreground: 28 6% 42%;
+    --accent: 33 26% 92%;
+    --accent-foreground: 24 10% 14%;
+    --destructive: 0 72% 48%;
     --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 89.8%;
-    --input: 0 0% 89.8%;
-    --ring: 0 0% 3.9%;
+    --border: 32 16% 87%;
+    --input: 32 16% 87%;
+    --ring: 24 10% 10%;
     --chart-1: 12 76% 61%;
     --chart-2: 173 58% 39%;
     --chart-3: 197 37% 24%;
     --chart-4: 43 74% 66%;
     --chart-5: 27 87% 67%;
-    --radius: 1.5rem;
-    --sidebar-background: 24, 35%, 92%;
-    --sidebar-foreground: 240 5.3% 26.1%;
-    --sidebar-primary: 240 5.9% 10%;
-    --sidebar-primary-foreground: 0 0% 98%;
-    --sidebar-accent: 30, 36%, 96%;
-    --sidebar-accent-foreground: 240 5.9% 10%;
-    --sidebar-border: 220 13% 91%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
-    /* --sidebar-width: 40rem;   */
-    /* --sidebar-width-icon: 4rem; */
+    --radius: 0.625rem;
+    --sidebar-background: 36 33% 96%;
+    --sidebar-foreground: 28 6% 30%;
+    --sidebar-primary: 24 10% 10%;
+    --sidebar-primary-foreground: 40 40% 98%;
+    --sidebar-accent: 33 26% 92%;
+    --sidebar-accent-foreground: 24 10% 14%;
+    --sidebar-border: 32 16% 87%;
+    --sidebar-ring: 24 10% 10%;
   }
   .dark {
-    --background: 0 0% 9%;
-    --foreground: 30 36% 96%;
-    --card: 0 0% 19%;
-    --card-foreground: 30 36% 96%;
-    --popover: 0 0% 19%;
-    --popover-foreground: 30 36% 96%;
-    --primary: 224 100% 91%;
-    --primary-foreground: 0 0% 9%;
-    --secondary: 224 100% 91%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 0 0% 36%;
-    --muted-foreground: 0 0% 63.9%;
-    --accent: 0 0% 14.9%;
-    --accent-foreground: 0 0% 98%;
-    --destructive: 0 62.8% 30.6%;
+    /* Deep neutral, near-white ink, flat layering just above the base. */
+    --background: 30 6% 7%;
+    --foreground: 36 20% 96%;
+    --card: 30 5% 11%;
+    --card-foreground: 36 20% 96%;
+    --popover: 30 5% 11%;
+    --popover-foreground: 36 20% 96%;
+    --primary: 36 20% 96%;
+    --primary-foreground: 24 10% 10%;
+    --secondary: 30 4% 16%;
+    --secondary-foreground: 36 20% 96%;
+    --muted: 30 4% 16%;
+    --muted-foreground: 30 5% 62%;
+    --accent: 30 4% 17%;
+    --accent-foreground: 36 20% 96%;
+    --destructive: 0 62% 45%;
     --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 14.9%;
-    --input: 0 0% 14.9%;
-    --ring: 0 0% 83.1%;
+    --border: 30 4% 17%;
+    --input: 30 4% 18%;
+    --ring: 36 20% 80%;
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;
     --chart-3: 30 80% 55%;
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%;
-    --sidebar-background: 240 5.9% 10%;
-    --sidebar-foreground: 240 4.8% 95.9%;
-    --sidebar-primary: 224.3 76.3% 48%;
-    --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 240 3.7% 15.9%;
-    --sidebar-accent-foreground: 240 4.8% 95.9%;
-    --sidebar-border: 240 3.7% 15.9%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
-    /* --sidebar-width: 40rem; */
-    /* --sidebar-width-icon: 4rem; */
+    --sidebar-background: 30 6% 7%;
+    --sidebar-foreground: 30 5% 70%;
+    --sidebar-primary: 36 20% 96%;
+    --sidebar-primary-foreground: 24 10% 10%;
+    --sidebar-accent: 30 4% 16%;
+    --sidebar-accent-foreground: 36 20% 96%;
+    --sidebar-border: 30 4% 17%;
+    --sidebar-ring: 36 20% 80%;
   }
 }
 

--- a/web/src/app/icons/page.tsx
+++ b/web/src/app/icons/page.tsx
@@ -59,8 +59,8 @@ export default function IconsPage() {
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
             <input
               type="text"
-              placeholder="Search..."
-              className="pl-10 h-10 w-full rounded-lg border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              placeholder="Search 51 brands…"
+              className="h-11 w-full rounded-lg border border-input bg-card pl-10 pr-3 text-sm outline-none transition-colors placeholder:text-muted-foreground focus:border-ring focus:ring-2 focus:ring-ring/20"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
             />
@@ -213,27 +213,28 @@ function IconCard({ icon }: { icon: IconInfo }) {
   const reactUsage = `<${currentName} size={24} />`;
 
   return (
-    <div className="group relative flex flex-col rounded-xl border border-border bg-card hover:border-primary/30 hover:shadow-sm transition-all">
+    <div className="group relative flex flex-col overflow-hidden rounded-xl border border-border bg-card transition-colors hover:border-foreground/25">
       {/* Mono Toggle */}
       {MonoIcon && (
         <button
           onClick={() => setShowMono(!showMono)}
           className={cn(
-            "absolute top-2 right-2 p-1.5 rounded-md transition-colors z-10",
+            "absolute top-2 right-2 z-10 flex h-7 w-7 items-center justify-center rounded-md opacity-0 transition-all group-hover:opacity-100",
             showMono
-              ? "bg-charcoal-700 text-white"
-              : "bg-muted text-muted-foreground hover:bg-muted/80"
+              ? "bg-foreground text-background opacity-100"
+              : "bg-background/80 text-muted-foreground hover:text-foreground"
           )}
           title={showMono ? "Show color" : "Show mono"}
         >
-          {showMono ? <Sun className="h-3 w-3" /> : <Moon className="h-3 w-3" />}
+          {showMono ? <Sun className="h-3.5 w-3.5" /> : <Moon className="h-3.5 w-3.5" />}
         </button>
       )}
 
-      {/* Icon Preview */}
+      {/* Icon Preview — color logos sit on a light plate (they're drawn for
+          light backgrounds); the mono/white variants get the dark plate. */}
       <div className={cn(
-        "flex items-center justify-center p-8 rounded-t-xl transition-colors",
-        showMono ? "bg-charcoal-900" : "bg-muted/30"
+        "flex items-center justify-center p-8 transition-colors",
+        showMono ? "bg-charcoal-900" : "bg-taupe-200"
       )}>
         {CurrentIcon && <CurrentIcon width={56} height={56} ref={svgRef} />}
       </div>

--- a/web/src/app/icons/page.tsx
+++ b/web/src/app/icons/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useEffect } from "react";
 import { Search, Copy, Download, Check, Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
 import * as Icons from "@cardog-icons/react";
 import { cn } from "../../lib/utils";
 import {
@@ -32,6 +33,14 @@ export default function IconsPage() {
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedBrand, setSelectedBrand] = useState<string | "All">("All");
   const [selectedCategory, setSelectedCategory] = useState<IconCategory | "All">("All");
+
+  // Drive the grid's default variant from the theme — mono/dark in dark mode,
+  // color in light — so the whole grid stays coherent. Gate on `mounted` to
+  // keep the first client paint identical to SSR (avoids a hydration mismatch).
+  const { resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  const themeMono = mounted && resolvedTheme === "dark";
 
   // Only show color variants in grid, mono available via toggle in card
   const filteredIcons = useMemo(() => {
@@ -157,7 +166,7 @@ export default function IconsPage() {
             {filteredIcons.length > 0 ? (
               <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
                 {filteredIcons.map((icon) => (
-                  <IconCard key={icon.id} icon={icon} />
+                  <IconCard key={icon.id} icon={icon} themeMono={themeMono} />
                 ))}
               </div>
             ) : (
@@ -182,8 +191,9 @@ export default function IconsPage() {
   );
 }
 
-function IconCard({ icon }: { icon: IconInfo }) {
-  const [showMono, setShowMono] = useState(false);
+function IconCard({ icon, themeMono }: { icon: IconInfo; themeMono: boolean }) {
+  // null = follow the theme default; true/false = explicit per-card override.
+  const [override, setOverride] = useState<boolean | null>(null);
   const [copied, setCopied] = useState<string | null>(null);
   const svgRef = React.useRef<SVGSVGElement>(null);
 
@@ -194,8 +204,9 @@ function IconCard({ icon }: { icon: IconInfo }) {
   const ColorIcon = Icons[colorName as keyof typeof Icons] as React.ComponentType<any>;
   const MonoIcon = Icons[monoName as keyof typeof Icons] as React.ComponentType<any>;
 
-  const CurrentIcon = showMono && MonoIcon ? MonoIcon : ColorIcon;
-  const currentName = showMono && MonoIcon ? monoName : colorName;
+  const showMono = (override ?? themeMono) && !!MonoIcon;
+  const CurrentIcon = showMono ? MonoIcon : ColorIcon;
+  const currentName = showMono ? monoName : colorName;
 
   const handleCopy = (type: string, content: string) => {
     navigator.clipboard.writeText(content);
@@ -217,11 +228,11 @@ function IconCard({ icon }: { icon: IconInfo }) {
       {/* Mono Toggle */}
       {MonoIcon && (
         <button
-          onClick={() => setShowMono(!showMono)}
+          onClick={() => setOverride(!showMono)}
           className={cn(
-            "absolute top-2 right-2 z-10 flex h-7 w-7 items-center justify-center rounded-md opacity-0 transition-all group-hover:opacity-100",
+            "absolute top-2 right-2 z-10 flex h-7 w-7 items-center justify-center rounded-md opacity-0 transition-all group-hover:opacity-100 focus-visible:opacity-100",
             showMono
-              ? "bg-foreground text-background opacity-100"
+              ? "bg-foreground text-background hover:bg-foreground/90"
               : "bg-background/80 text-muted-foreground hover:text-foreground"
           )}
           title={showMono ? "Show color" : "Show mono"}

--- a/web/src/app/packages/page.tsx
+++ b/web/src/app/packages/page.tsx
@@ -25,7 +25,9 @@ const packages = [
 export default function PackagesPage() {
   return (
     <div className="container py-8 md:py-12">
-      <h1 className="text-3xl font-bold mb-4">Packages</h1>
+      <h1 className="text-3xl font-semibold tracking-tight md:text-4xl mb-4">
+        Packages
+      </h1>
       <p className="text-lg text-muted-foreground mb-8 max-w-3xl">
         Cardog Icons is available in various packages for different platforms
         and frameworks.
@@ -66,7 +68,9 @@ export default function PackagesPage() {
       </div>
 
       <div className="mt-16 border-t pt-10">
-        <h2 className="text-2xl font-bold mb-6">Installation Examples</h2>
+        <h2 className="text-2xl font-semibold tracking-tight mb-6">
+          Installation Examples
+        </h2>
 
         <div className="space-y-6">
           <div className="border rounded-lg p-6">

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { LogoGrid } from "../components/logo-grid";
-import { PackageShowcase } from "../components/package-showcase";
+import { InstallList } from "../components/package-showcase";
 import { iconCounts } from "../lib/icons";
 
 export default function Home() {
@@ -40,54 +40,14 @@ export default function Home() {
         </div>
       </section>
 
-      {/* Installation */}
-      <section className="border-t border-border py-20 md:py-28">
-        <div className="container">
-          <div className="mx-auto max-w-2xl text-center">
-            <span className="text-sm font-medium text-muted-foreground">
-              Installation
-            </span>
-            <h2 className="mt-3 text-3xl font-semibold tracking-tight md:text-4xl">
-              Drop it into any stack
-            </h2>
-            <p className="mt-4 text-base text-muted-foreground">
-              One source of truth for every car brand mark — shipped for React,
-              React Native, and plain SVG. Fully typed, fully tree-shakeable.
-            </p>
-          </div>
-
-          <div className="mt-14">
-            <PackageShowcase />
-          </div>
-        </div>
-      </section>
-
-      {/* CTA */}
-      <section className="border-t border-border py-20 md:py-28">
-        <div className="container">
-          <div className="mx-auto flex max-w-3xl flex-col items-center rounded-3xl border border-border bg-card px-6 py-14 text-center md:px-12">
-            <h2 className="text-3xl font-semibold tracking-tight md:text-4xl">
-              Ready to get started?
-            </h2>
-            <p className="mt-4 max-w-xl text-base text-muted-foreground md:text-lg">
-              Read the docs to wire Cardog Icons into your project in a couple of
-              lines — or jump straight into the full collection.
-            </p>
-            <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
-              <a
-                href="/docs"
-                className="inline-flex items-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-              >
-                View documentation
-                <ArrowRightIcon className="h-4 w-4" />
-              </a>
-              <a
-                href="/icons"
-                className="rounded-full border border-input bg-background px-6 py-3 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
-              >
-                Browse all icons
-              </a>
-            </div>
+      {/* Install — minimal, editorial */}
+      <section className="border-t border-border py-20 md:py-24">
+        <div className="container max-w-3xl">
+          <h2 className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            Install
+          </h2>
+          <div className="mt-6">
+            <InstallList />
           </div>
         </div>
       </section>

--- a/web/src/app/updates/page.tsx
+++ b/web/src/app/updates/page.tsx
@@ -90,7 +90,9 @@ export default function UpdatesPage() {
       <div className="container py-12 max-w-3xl">
         {/* Header */}
         <div className="mb-12">
-          <h1 className="text-4xl font-bold tracking-tight mb-4">Updates</h1>
+          <h1 className="text-3xl font-semibold tracking-tight md:text-4xl mb-4">
+            Updates
+          </h1>
           <p className="text-lg text-muted-foreground">
             Latest changes and improvements to Cardog Icons.
           </p>

--- a/web/src/components/navbar.tsx
+++ b/web/src/components/navbar.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { Search, Menu, X } from "lucide-react";
 import { ModeToggle } from "./mode-toggle";
 import { useState } from "react";
 import { cn } from "../lib/utils";
-import { Logo, Logomark } from "./logo";
+import { Logomark } from "./logo";
 
 const navItems = [
   { name: "Home", href: "/" },
@@ -14,74 +15,84 @@ const navItems = [
   { name: "Updates", href: "/updates" },
 ];
 
+function useIsActive() {
+  const pathname = usePathname();
+  return (href: string) =>
+    href === "/" ? pathname === "/" : pathname.startsWith(href);
+}
+
 export function Navbar() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const isActive = useIsActive();
 
   return (
-    <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-      <div className="container flex h-16 items-center">
-        <div className="mr-4 flex">
-          <Link href="/" className="flex items-center space-x-2">
-            <span className="font-bold text-xl">
-              <Logomark className="h-8 w-auto" />
-            </span>
-            <X className="h-4 w-4" />
-            <span className="text-xl font-normal">Icons</span>
-          </Link>
-        </div>
-        <div className="flex flex-1 items-center justify-end space-x-2 md:justify-end">
-          <nav className="hidden md:flex items-center space-x-6 text-sm font-medium">
-            {navItems.map((item) => (
-              <Link
-                key={item.href}
-                href={item.href}
-                className="transition-colors hover:text-foreground/80 text-foreground/60"
-              >
-                {item.name}
-              </Link>
-            ))}
-          </nav>
-          <div className="flex items-center space-x-1">
+    <header className="sticky top-0 z-50 w-full border-b border-border bg-background/80 backdrop-blur-md">
+      <div className="container flex h-16 items-center justify-between">
+        <Link href="/" className="flex items-center gap-2">
+          <Logomark className="h-7 w-auto" />
+          <X className="h-3.5 w-3.5 text-muted-foreground" />
+          <span className="text-lg font-medium tracking-tight">Icons</span>
+        </Link>
+
+        <nav className="hidden items-center gap-1 md:flex">
+          {navItems.map((item) => (
             <Link
-              href="/icons?searchFocus=true"
-              className="group p-2 rounded-md hover:bg-accent hover:text-accent-foreground"
-              aria-label="Search icons"
+              key={item.href}
+              href={item.href}
+              className={cn(
+                "rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+                isActive(item.href)
+                  ? "bg-accent text-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
             >
-              <Search className="h-5 w-5" />
-              <span className="sr-only">Search icons</span>
+              {item.name}
             </Link>
-            <ModeToggle />
-            <button
-              className="p-2 rounded-md hover:bg-accent hover:text-accent-foreground md:hidden"
-              onClick={() => setIsMenuOpen(!isMenuOpen)}
-            >
-              <Menu className="h-5 w-5" />
-              <span className="sr-only">Toggle menu</span>
-            </button>
-          </div>
+          ))}
+        </nav>
+
+        <div className="flex items-center gap-0.5">
+          <Link
+            href="/icons?searchFocus=true"
+            className="flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            aria-label="Search icons"
+          >
+            <Search className="h-[18px] w-[18px]" />
+          </Link>
+          <ModeToggle />
+          <button
+            className="flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground md:hidden"
+            onClick={() => setIsMenuOpen(!isMenuOpen)}
+            aria-label="Toggle menu"
+          >
+            <Menu className="h-[18px] w-[18px]" />
+          </button>
         </div>
       </div>
+
       {/* Mobile menu */}
       <div
         className={cn(
-          "md:hidden absolute w-full bg-background border-b",
+          "border-b border-border bg-background md:hidden",
           isMenuOpen ? "block" : "hidden"
         )}
       >
-        <nav className="container py-4">
-          <ul className="grid gap-3">
-            {navItems.map((item) => (
-              <li key={item.href}>
-                <Link
-                  href={item.href}
-                  className="block px-2 py-1 text-lg font-medium"
-                  onClick={() => setIsMenuOpen(false)}
-                >
-                  {item.name}
-                </Link>
-              </li>
-            ))}
-          </ul>
+        <nav className="container grid gap-1 py-3">
+          {navItems.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={cn(
+                "rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                isActive(item.href)
+                  ? "bg-accent text-foreground"
+                  : "text-muted-foreground hover:bg-accent hover:text-foreground"
+              )}
+              onClick={() => setIsMenuOpen(false)}
+            >
+              {item.name}
+            </Link>
+          ))}
         </nav>
       </div>
     </header>

--- a/web/src/components/package-showcase.tsx
+++ b/web/src/components/package-showcase.tsx
@@ -3,99 +3,38 @@
 import React from "react";
 
 type Pkg = {
-  badge: string;
   name: string;
+  tag: string;
   description: string;
   install: string;
-  lang: string;
-  code: string;
   href: string;
 };
 
 const PACKAGES: Pkg[] = [
   {
-    badge: "React 19+",
     name: "@cardog-icons/react",
-    description: "Tree-shakeable React components with full TypeScript support.",
+    tag: "React 19+",
+    description: "Tree-shakeable components, fully typed.",
     install: "npm i @cardog-icons/react",
-    lang: "tsx",
-    code: `import { BMWLogo, TeslaIcon } from '@cardog-icons/react';
-
-<BMWLogo size={48} />
-<TeslaIcon className="text-red-500" />`,
     href: "https://www.npmjs.com/package/@cardog-icons/react",
   },
   {
-    badge: "Expo · RN 0.60+",
     name: "@cardog-icons/react-native",
-    description: "Native SVG components powered by react-native-svg.",
+    tag: "Expo · React Native",
+    description: "Native SVG via react-native-svg.",
     install: "npm i @cardog-icons/react-native",
-    lang: "tsx",
-    code: `import { AudiLogo } from '@cardog-icons/react-native';
-
-<AudiLogo width={64} height={64} />`,
     href: "https://www.npmjs.com/package/@cardog-icons/react-native",
   },
   {
-    badge: "Raw SVGs",
     name: "@cardog-icons/core",
-    description: "Optimized SVG files for any framework or vanilla project.",
+    tag: "Vanilla SVG",
+    description: "Optimized SVGs for any project.",
     install: "npm i @cardog-icons/core",
-    lang: "ts",
-    code: `import { icons } from '@cardog-icons/core';
-
-const svg = icons['bmw-logo'];
-document.body.innerHTML = svg;`,
     href: "https://www.npmjs.com/package/@cardog-icons/core",
   },
 ];
 
-// Minimal, correctness-first tokenizer. Only colours things it can match
-// unambiguously — strings, line comments and a small keyword set — and leaves
-// everything else untouched, so snippets are never mangled.
-const TOKEN =
-  /(\/\/[^\n]*)|('[^']*'|"[^"]*"|`[^`]*`)|\b(import|from|const|let|export|default|return)\b/g;
-
-function highlight(code: string): React.ReactNode[] {
-  const nodes: React.ReactNode[] = [];
-  let last = 0;
-  let match: RegExpExecArray | null;
-  let key = 0;
-
-  TOKEN.lastIndex = 0;
-  while ((match = TOKEN.exec(code)) !== null) {
-    if (match.index > last) {
-      nodes.push(code.slice(last, match.index));
-    }
-    const [text, comment, str, keyword] = match;
-    if (comment) {
-      nodes.push(
-        <span key={key++} className="text-charcoal-400">
-          {comment}
-        </span>,
-      );
-    } else if (str) {
-      nodes.push(
-        <span key={key++} className="text-emerald-300">
-          {str}
-        </span>,
-      );
-    } else if (keyword) {
-      nodes.push(
-        <span key={key++} className="text-violet-300">
-          {keyword}
-        </span>,
-      );
-    } else {
-      nodes.push(text);
-    }
-    last = match.index + text.length;
-  }
-  if (last < code.length) nodes.push(code.slice(last));
-  return nodes;
-}
-
-function CopyButton({ value, label }: { value: string; label: string }) {
+function CopyCommand({ value }: { value: string }) {
   const [copied, setCopied] = React.useState(false);
 
   const onCopy = React.useCallback(async () => {
@@ -112,82 +51,57 @@ function CopyButton({ value, label }: { value: string; label: string }) {
     <button
       type="button"
       onClick={onCopy}
-      aria-label={label}
-      className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-charcoal-400 transition-colors hover:bg-white/10 hover:text-taupe-100"
+      aria-label={`Copy: ${value}`}
+      className="group/cmd inline-flex items-center gap-3 rounded-md border border-transparent px-3 py-2 font-mono text-[13px] text-muted-foreground transition-colors hover:border-border hover:bg-muted/60 hover:text-foreground"
     >
-      {copied ? <CheckIcon /> : <CopyIcon />}
+      <span className="whitespace-nowrap">
+        <span className="select-none text-muted-foreground/50">$ </span>
+        {value}
+      </span>
+      {copied ? (
+        <CheckIcon className="h-3.5 w-3.5 text-emerald-500" />
+      ) : (
+        <CopyIcon className="h-3.5 w-3.5 opacity-0 transition-opacity group-hover/cmd:opacity-100" />
+      )}
     </button>
   );
 }
 
-function PackageCard({ pkg }: { pkg: Pkg }) {
+export function InstallList() {
   return (
-    <div className="flex h-full flex-col rounded-2xl border border-border bg-card p-6 transition-colors hover:border-foreground/20">
-      <div className="flex items-center justify-between">
-        <span className="rounded-full border border-border bg-background px-2.5 py-0.5 text-xs font-medium text-muted-foreground">
-          {pkg.badge}
-        </span>
-        <a
-          href={pkg.href}
-          target="_blank"
-          rel="noreferrer noopener"
-          className="inline-flex items-center gap-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
-        >
-          npm
-          <ArrowUpRightIcon />
-        </a>
-      </div>
-
-      <h3 className="mt-4 font-mono text-[15px] font-semibold text-foreground">
-        {pkg.name}
-      </h3>
-      <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-        {pkg.description}
-      </p>
-
-      {/* Install command */}
-      <div className="mt-5 flex items-center gap-2 rounded-lg border border-border bg-charcoal-900 py-1.5 pl-3 pr-1.5 font-mono text-xs">
-        <span className="select-none text-emerald-400">$</span>
-        <span className="flex-1 overflow-x-auto whitespace-nowrap text-taupe-200 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-          {pkg.install}
-        </span>
-        <CopyButton value={pkg.install} label={`Copy install command for ${pkg.name}`} />
-      </div>
-
-      {/* Code window */}
-      <div className="mt-3 flex flex-1 flex-col overflow-hidden rounded-lg border border-border bg-charcoal-900">
-        <div className="flex items-center justify-between border-b border-white/5 px-3 py-1.5">
-          <span className="font-mono text-[11px] uppercase tracking-wider text-charcoal-400">
-            {pkg.lang}
-          </span>
-          <CopyButton value={pkg.code} label={`Copy example for ${pkg.name}`} />
-        </div>
-        <div className="relative flex-1">
-          <pre className="h-full overflow-x-auto p-3 pr-8 font-mono text-xs leading-relaxed text-taupe-200 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-            <code>{highlight(pkg.code)}</code>
-          </pre>
-          {/* Fade long lines into the edge so horizontal scroll reads cleanly */}
-          <div className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-charcoal-900 to-transparent" />
-        </div>
-      </div>
-    </div>
-  );
-}
-
-export function PackageShowcase() {
-  return (
-    <div className="grid grid-cols-1 items-stretch gap-6 md:grid-cols-3">
+    <div className="divide-y divide-border border-y border-border">
       {PACKAGES.map((pkg) => (
-        <PackageCard key={pkg.name} pkg={pkg} />
+        <div
+          key={pkg.name}
+          className="flex flex-col gap-3 py-6 md:flex-row md:items-center md:justify-between"
+        >
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1">
+              <a
+                href={pkg.href}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="font-mono text-sm font-medium text-foreground underline-offset-4 hover:underline"
+              >
+                {pkg.name}
+              </a>
+              <span className="text-xs text-muted-foreground">{pkg.tag}</span>
+            </div>
+            <p className="mt-1 text-sm text-muted-foreground">{pkg.description}</p>
+          </div>
+          <div className="-ml-3 md:ml-0 md:shrink-0">
+            <CopyCommand value={pkg.install} />
+          </div>
+        </div>
       ))}
     </div>
   );
 }
 
-function CopyIcon() {
+function CopyIcon({ className }: { className?: string }) {
   return (
     <svg
-      className="h-3.5 w-3.5"
+      className={className}
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
@@ -201,10 +115,10 @@ function CopyIcon() {
   );
 }
 
-function CheckIcon() {
+function CheckIcon({ className }: { className?: string }) {
   return (
     <svg
-      className="h-3.5 w-3.5 text-emerald-400"
+      className={className}
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
@@ -213,23 +127,6 @@ function CheckIcon() {
       strokeLinejoin="round"
     >
       <path d="M20 6 9 17l-5-5" />
-    </svg>
-  );
-}
-
-function ArrowUpRightIcon() {
-  return (
-    <svg
-      className="h-3 w-3"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M7 7h10v10" />
-      <path d="M7 17 17 7" />
     </svg>
   );
 }

--- a/web/src/components/ui/badge.tsx
+++ b/web/src/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  "inline-flex items-center justify-center rounded-full border px-2.5 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:ring-2 focus-visible:ring-ring/30 aria-invalid:border-destructive transition-colors overflow-hidden",
   {
     variants: {
       variant: {

--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -5,25 +5,24 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[color,box-shadow] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background aria-invalid:ring-destructive/30 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
-        default:
-          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive:
-          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40",
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90 focus-visible:ring-destructive/40",
         outline:
-          "border border-input bg-background shadow-xs hover:bg-accent hover:text-accent-foreground",
+          "border border-border bg-transparent hover:bg-accent hover:text-accent-foreground",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+        link: "text-foreground underline-offset-4 hover:underline",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
         sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        lg: "h-11 rounded-md px-6 has-[>svg]:px-4",
         icon: "size-9",
       },
     },

--- a/web/src/components/ui/card.tsx
+++ b/web/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6",
         className
       )}
       {...props}

--- a/web/src/components/ui/input.tsx
+++ b/web/src/components/ui/input.tsx
@@ -8,9 +8,9 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "border-input file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
-        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        "border-input file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base transition-colors outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/20",
+        "aria-invalid:border-destructive aria-invalid:ring-destructive/20",
         className
       )}
       {...props}


### PR DESCRIPTION
Whole-app visual refresh toward a **flat, editorial** aesthetic — building on the infinite-grid hero from #7.

## Design tokens (`globals.css`)
- **Ink primary** (near-black in light, near-white in dark) for crisp, high-contrast actions — replaces the washed-out pale blue.
- Warm neutral scale, **tighter base radius** (`1.5rem → 0.625rem`), and no reliance on elevation/shadows.

## Primitives — flattened
`button`, `input`, `card`, `badge`: removed shadows, modern 2px focus rings, ink-based variants.

## Chrome & pages
- **navbar** — lighter, with an active-link pill (`usePathname`).
- **icons page** — flat hairline cards (no hover shadow); color logos now preview on a **light plate** so black/dark marks stay visible in dark mode, while the mono/white variants keep the charcoal plate; modernized search + sidebar filters.
- **home below-fold** — replaced the tired 3-card grid with a **minimal, editorial install list** (divider-separated rows, click-to-copy commands) and **removed the CTA section** entirely.
- **docs / packages / updates** — unified heading style; flattened the docs "What's New" callout (dropped the gradient).

## Verification
- `next build` passes; all routes prerender.
- New/changed files type-clean (the repo's pre-existing duplicate-`@types/react` errors are unaffected; build runs with `ignoreBuildErrors`).
- Verified in-browser across light + dark: home (hero + install list), icons grid, docs. Click-to-copy confirmed working; no console errors.

Screenshots in thread.